### PR TITLE
chore(stacks): add new mariadb galera

### DIFF
--- a/new-stack-templates.json
+++ b/new-stack-templates.json
@@ -97,6 +97,21 @@
   },
   {
     "categories": [
+      "database"
+    ],
+    "description": "MariaDB Galera v25",
+    "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mariadb.png",
+    "note": "List: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json\">https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json</a><br/>Source: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml\">https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml</a>",
+    "platform": "linux",
+    "repository": {
+      "stackfile": "stacks/camunda-ci-mariadb-galera-new/docker-stack.yml",
+      "url": "https://github.com/camunda-ci/portainer-templates"
+    },
+    "title": "MariaDB Galera v25",
+    "type": 2
+  },
+  {
+    "categories": [
       "server"
     ],
     "description": "NOTE: Please first start a database container and fill out the database fields before creating this container!",

--- a/stack-templates.json
+++ b/stack-templates.json
@@ -99,7 +99,7 @@
     "categories": [
       "database"
     ],
-    "description": "MariaDB GALERA NEW",
+    "description": "MariaDB Galera v25",
     "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mariadb.png",
     "note": "List: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json\">https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json</a><br/>Source: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml\">https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml</a>",
     "platform": "linux",

--- a/stack-templates.json
+++ b/stack-templates.json
@@ -107,7 +107,7 @@
       "stackfile": "stacks/camunda-ci-mariadb-galera-new/docker-stack.yml",
       "url": "https://github.com/camunda-ci/portainer-templates"
     },
-    "title": "MariaDB GALERA NEW",
+    "title": "MariaDB Galera v25",
     "type": 2
   },
   {

--- a/stack-templates.json
+++ b/stack-templates.json
@@ -95,6 +95,27 @@
     "title": "MariaDB v10.3",
     "type": 2
   },
+    {
+    "categories": [
+      "database"
+    ],
+    "description": "MariaDB GALERA NEW",
+    "env": [
+      {
+        "label": "READ-COMMITTED",
+        "name": "TRANSACTION_ISOLATION_LEVEL"
+      }
+    ],
+    "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mariadb.png",
+    "note": "List: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json\">https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json</a><br/>Source: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml\">https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml</a>",
+    "platform": "linux",
+    "repository": {
+      "stackfile": "stacks/camunda-ci-mariadb-galera-new/docker-stack.yml",
+      "url": "https://github.com/camunda-ci/portainer-templates"
+    },
+    "title": "MariaDB GALERA NEW",
+    "type": 2
+  },
   {
     "categories": [
       "server"

--- a/stack-templates.json
+++ b/stack-templates.json
@@ -100,12 +100,6 @@
       "database"
     ],
     "description": "MariaDB GALERA NEW",
-    "env": [
-      {
-        "label": "READ-COMMITTED",
-        "name": "TRANSACTION_ISOLATION_LEVEL"
-      }
-    ],
     "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mariadb.png",
     "note": "List: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json\">https://github.com/camunda-ci/portainer-templates/blob/master/stack-templates.json</a><br/>Source: <a href=\"https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml\">https://github.com/camunda-ci/portainer-templates/blob/master/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml</a>",
     "platform": "linux",

--- a/stack-templates.json
+++ b/stack-templates.json
@@ -95,7 +95,7 @@
     "title": "MariaDB v10.3",
     "type": 2
   },
-    {
+  {
     "categories": [
       "database"
     ],

--- a/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml
+++ b/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml
@@ -5,8 +5,6 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    environment:
-      - TRANSACTION_ISOLATION_LEVEL=${TRANSACTION_ISOLATION_LEVEL:-REPEATABLE-READ}
     image: gcr.io/ci-30-162810/mariadb:g25v0.3.2
     ports:
       - 3306/tcp

--- a/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml
+++ b/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml
@@ -1,0 +1,15 @@
+---
+services:
+  main:
+    command: /usr/local/bin/start-container.sh
+    deploy:
+      restart_policy:
+        condition: on-failure
+    environment:
+      - TRANSACTION_ISOLATION_LEVEL=${TRANSACTION_ISOLATION_LEVEL:-REPEATABLE-READ}
+    image: gcr.io/ci-30-162810/mariadb:g25v0.3.2
+    ports:
+      - 3306/tcp
+      - 22/tcp
+    restart: on-failure
+version: '3'


### PR DESCRIPTION
Old image of galera seems to not be working (not sure if it was working before)
We need to test a failure related to the patch release that is scheduled for the end of the week.
I would like to have a local setup as close as possible to CI