### PR TITLE
chore(gar-migration): Migrate links from GCR to GAR

### DIFF
--- a/stack-templates.json
+++ b/stack-templates.json
@@ -1256,7 +1256,7 @@
     "platform": "linux",
     "ports": ["50000/tcp", "22/tcp"],
     "privileged": true,
-    "registry": "gcr.io/ci-30-162810",
+    "registry": "europe-west1-docker.pkg.dev/ci-30-162810/main",
     "restart_policy": "on-failure",
     "title": "DB2 v11.5",
     "type": 1

--- a/stacks/camunda-ci-cockroachdb-20.1/docker-stack.yml
+++ b/stacks/camunda-ci-cockroachdb-20.1/docker-stack.yml
@@ -4,7 +4,7 @@ services:
       restart_policy:
         condition: on-failure
     environment: []
-    image: gcr.io/ci-30-162810/cockroachdb:20.1v0.1.3
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/cockroachdb:20.1v0.1.3
     ports:
       - 26257/tcp
       - 8080/tcp

--- a/stacks/camunda-ci-mariadb-10.2/docker-stack.yml
+++ b/stacks/camunda-ci-mariadb-10.2/docker-stack.yml
@@ -7,7 +7,7 @@ services:
         condition: on-failure
     environment:
       - TRANSACTION_ISOLATION_LEVEL=${TRANSACTION_ISOLATION_LEVEL:-REPEATABLE-READ}
-    image: gcr.io/ci-30-162810/mariadb:10.2v0.3.2
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/mariadb:10.2v0.3.2
     ports:
       - 3306/tcp
       - 22/tcp

--- a/stacks/camunda-ci-mariadb-10.3/docker-stack.yml
+++ b/stacks/camunda-ci-mariadb-10.3/docker-stack.yml
@@ -7,7 +7,7 @@ services:
         condition: on-failure
     environment:
       - TRANSACTION_ISOLATION_LEVEL=${TRANSACTION_ISOLATION_LEVEL:-REPEATABLE-READ}
-    image: gcr.io/ci-30-162810/mariadb:10.3v0.3.2
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/mariadb:10.3v0.3.2
     ports:
       - 3306/tcp
       - 22/tcp

--- a/stacks/camunda-ci-mariadb-10.6/docker-stack.yml
+++ b/stacks/camunda-ci-mariadb-10.6/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/mariadb:10.6v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/mariadb:10.6v0.1.0
     ports:
       - 3306/tcp
     restart: on-failure

--- a/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml
+++ b/stacks/camunda-ci-mariadb-galera-new/docker-stack.yml
@@ -5,7 +5,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/mariadb:g25v0.3.2
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/mariadb:g25v0.3.2
     ports:
       - 3306/tcp
       - 22/tcp

--- a/stacks/camunda-ci-mysql-8.0/docker-stack.yml
+++ b/stacks/camunda-ci-mysql-8.0/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/mysql:8.0v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/mysql:8.0v0.1.0
     ports:
       - 3306/tcp
     restart: on-failure

--- a/stacks/camunda-ci-oracle-19/docker-stack.yml
+++ b/stacks/camunda-ci-oracle-19/docker-stack.yml
@@ -6,7 +6,7 @@ services:
       restart_policy:
         condition: on-failure
     environment: []
-    image: gcr.io/ci-30-162810/oracle:19v0.2.2
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/oracle:19v0.2.2
     ports:
       - 1521/tcp
       - 22/tcp

--- a/stacks/camunda-ci-postgresql-10.13/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-10.13/docker-stack.yml
@@ -6,7 +6,7 @@ services:
       restart_policy:
         condition: on-failure
     environment: []
-    image: gcr.io/ci-30-162810/postgresql:10.13v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:10.13v0.1.0
     ports:
       - 5432/tcp
       - 22/tcp

--- a/stacks/camunda-ci-postgresql-10.7/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-10.7/docker-stack.yml
@@ -6,7 +6,7 @@ services:
       restart_policy:
         condition: on-failure
     environment: []
-    image: gcr.io/ci-30-162810/postgresql:10.7v0.2.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:10.7v0.2.0
     ports:
       - 5432/tcp
       - 22/tcp

--- a/stacks/camunda-ci-postgresql-11.2/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-11.2/docker-stack.yml
@@ -6,7 +6,7 @@ services:
       restart_policy:
         condition: on-failure
     environment: []
-    image: gcr.io/ci-30-162810/postgresql:11.2v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:11.2v0.1.0
     ports:
       - 5432/tcp
       - 22/tcp

--- a/stacks/camunda-ci-postgresql-12.2/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-12.2/docker-stack.yml
@@ -6,7 +6,7 @@ services:
       restart_policy:
         condition: on-failure
     environment: []
-    image: gcr.io/ci-30-162810/postgresql:12.2v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:12.2v0.1.0
     ports:
       - 5432/tcp
       - 22/tcp

--- a/stacks/camunda-ci-postgresql-13.2/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-13.2/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/postgresql:13.2v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:13.2v0.1.0
     ports:
       - 5432/tcp
     restart: on-failure

--- a/stacks/camunda-ci-postgresql-14.2/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-14.2/docker-stack.yml
@@ -5,7 +5,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/postgresql:14.2v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:14.2v0.1.0
     ports:
     - 5432/tcp
     restart: on-failure

--- a/stacks/camunda-ci-postgresql-15.0/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-15.0/docker-stack.yml
@@ -5,7 +5,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/postgresql:15.0v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:15.0v0.1.0
     ports:
     - 5432/tcp
     restart: on-failure

--- a/stacks/camunda-ci-postgresql-16.0/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-16.0/docker-stack.yml
@@ -5,7 +5,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/postgresql:16.0v0.1.0
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/postgresql:16.0v0.1.0
     ports:
     - 5432/tcp
     restart: on-failure

--- a/stacks/camunda-ci-sqlserver-2017/docker-stack.yml
+++ b/stacks/camunda-ci-sqlserver-2017/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/mssql:2017v0.1.1
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/mssql:2017v0.1.1
     ports:
       - 1433/tcp
     restart: on-failure

--- a/stacks/camunda-ci-sqlserver-2019/docker-stack.yml
+++ b/stacks/camunda-ci-sqlserver-2019/docker-stack.yml
@@ -4,7 +4,7 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    image: gcr.io/ci-30-162810/mssql:2019v0.1.1
+    image: europe-west1-docker.pkg.dev/ci-30-162810/main/mssql:2019v0.1.1
     ports:
       - 1433/tcp
     restart: on-failure

--- a/templates.json
+++ b/templates.json
@@ -80,7 +80,7 @@
       "22/tcp"
     ],
     "privileged": true,
-    "registry": "gcr.io/ci-30-162810",
+    "registry": "europe-west1-docker.pkg.dev/ci-30-162810/main",
     "command": "/usr/local/bin/start-container.sh",
     "restart_policy": "on-failure"
   },


### PR DESCRIPTION
## Description
This pr switched the links for the docker stacks form gcr to gar

## Testing
Tested by creating a few stacks in dev. All stacks reference:
`repo`:  https://github.com/camunda/portainer-templates
`branch`: ref/heads/main

Stacks:
- http://dev.portainer.camunda.cloud/#/stacks/dummystack?id=16&type=1&external=false
- http://dev.portainer.camunda.cloud/#/stacks/stack-camunda-ci-cockroachdb?id=19&type=1&external=false

Services:
- http://dev.portainer.camunda.cloud/#/tasks/zcxdffgri9732qk65bi6fonnt
- http://dev.portainer.camunda.cloud/#/tasks/zlha8i2qcvtshznhuupfwr0h4