### PR TITLE
chore(7.22): bump docker qa stack to alpha6

### DIFF
--- a/stacks/weblogic14r1-722-latest/docker-stack.yml
+++ b/stacks/weblogic14r1-722-latest/docker-stack.yml
@@ -10,7 +10,7 @@ services:
       - DATABASE_PORT=${DATABASE_PORT}
       - DATABASE_NAME=${DATABASE_NAME}
       - DATABASE_TYPE=${DATABASE_TYPE}
-    image: registry.camunda.cloud/team-cambpm/weblogic14r1:7.22.0-alpha5-ee
+    image: registry.camunda.cloud/team-cambpm/weblogic14r1:7.22.0-alpha6-ee
     ports:
       - 7001/tcp
     restart: on-failure


### PR DESCRIPTION
**Related-to**: https://github.com/camunda/camunda-bpm-platform/issues/4592