### PR TITLE
feat(postgres): add support for Postgres 18

### DIFF
--- a/new-stack-templates.json
+++ b/new-stack-templates.json
@@ -195,6 +195,21 @@
     "type": 2
   },
   {
+    "categories": [
+      "database"
+    ],
+    "description": "PostgreSQL v18.0",
+    "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/postgres.png",
+    "note": "List: <a href=\"https://github.com/camunda/portainer-templates/blob/master/stack-templates.json\">https://github.com/camunda/portainer-templates/blob/master/stack-templates.json</a><br/>Source: <a href=\"https://github.com/camunda/portainer-templates/blob/master/stacks/camunda-ci-postgresql-18.0/docker-stack.yml\">https://github.com/camunda/portainer-templates/blob/master/stacks/camunda-ci-postgresql-18.0/docker-stack.yml</a>",
+    "platform": "linux",
+    "repository": {
+      "stackfile": "stacks/camunda-ci-postgresql-18.0/docker-stack.yml",
+      "url": "https://github.com/camunda/portainer-templates"
+    },
+    "title": "PostgreSQL v18.0",
+    "type": 2
+  },
+  {
     "categories": ["database"],
     "description": "CockroachDB v20.1.3",
     "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cockroachdb.png",

--- a/stack-templates.json
+++ b/stack-templates.json
@@ -224,6 +224,21 @@
     "categories": [
       "database"
     ],
+    "description": "PostgreSQL v18.0",
+    "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/postgres.png",
+    "note": "List: <a href=\"https://github.com/camunda/portainer-templates/blob/master/stack-templates.json\">https://github.com/camunda/portainer-templates/blob/master/stack-templates.json</a><br/>Source: <a href=\"https://github.com/camunda/portainer-templates/blob/master/stacks/camunda-ci-postgresql-18.0/docker-stack.yml\">https://github.com/camunda/portainer-templates/blob/master/stacks/camunda-ci-postgresql-18.0/docker-stack.yml</a>",
+    "platform": "linux",
+    "repository": {
+      "stackfile": "stacks/camunda-ci-postgresql-18.0/docker-stack.yml",
+      "url": "https://github.com/camunda/portainer-templates"
+    },
+    "title": "PostgreSQL v18.0",
+    "type": 2
+  },
+  {
+    "categories": [
+      "database"
+    ],
     "description": "CockroachDB v20.1.3",
     "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cockroachdb.png",
     "note": "List: <a href=\"https://github.com/camunda/portainer-templates/blob/master/stack-templates.json\">https://github.com/camunda/portainer-templates/blob/master/stack-templates.json</a><br/>Source: <a href=\"https://github.com/camunda/portainer-templates/blob/master/stacks/camunda-ci-cockroachdb-20.1/docker-stack.yml\">https://github.com/camunda/portainer-templates/blob/master/stacks/camunda-ci-cockroachdb-20.1/docker-stack.yml</a>",

--- a/stacks/camunda-ci-postgresql-18.0/docker-stack.yml
+++ b/stacks/camunda-ci-postgresql-18.0/docker-stack.yml
@@ -1,0 +1,15 @@
+---
+version: '3'
+services:
+  main:
+    deploy:
+      restart_policy:
+        condition: on-failure
+    image: docker.io/library/postgres:18.0
+    environment:
+      - POSTGRES_USER=camunda
+      - POSTGRES_PASSWORD=camunda
+      - POSTGRES_DB=process-engine
+    ports:
+    - 5432/tcp
+    restart: on-failure


### PR DESCRIPTION
feat(postgres): add support for Postgres 18
- add Postgres 18 template. 
Related to: https://github.com/camunda/camunda-bpm-platform-maintenance/issues/1659